### PR TITLE
Fix buildCondition for 'false' boolean value.

### DIFF
--- a/src/MongoLite/Database.php
+++ b/src/MongoLite/Database.php
@@ -225,7 +225,7 @@ class UtilArrayQuery {
                         $d .= '["'.$key.'"]';
                     }
 
-                    $fn[] = is_array($value) ? "\\MongoLite\\UtilArrayQuery::check({$d}, ".var_export($value, true).")": "({$d}==".(is_string($value) ? "'{$value}'": $value).")";
+                    $fn[] = is_array($value) ? "\\MongoLite\\UtilArrayQuery::check({$d}, ".var_export($value, true).")": "({$d}==".(is_string($value) ? "'{$value}'": var_export($value, true)).")";
             }
         }
 


### PR DESCRIPTION
An exception occurs when casting a boolean value to a string. Apparently the problem only happens when the value is false.

The following query fails.

``` php
$collection("posts")->find(["public"=>false])->toArray();
```
